### PR TITLE
Add Solana USDC payment options endpoint and EVM refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Returns server health status and configuration.
 
 #### `GET /getWalletPaymentOptions`
 
-Enhanced endpoint that returns detailed wallet payment options with token balances.
+Enhanced endpoint that returns detailed wallet payment options with token balances for EVM chains.
 
 **Query Parameters:**
 
@@ -38,7 +38,26 @@ Enhanced endpoint that returns detailed wallet payment options with token balanc
 }
 ```
 
-**Response Format:**
+#### `GET /getSolanaPaymentOptions`
+
+Enhanced endpoint that returns detailed payment options with USDC token balance for Solana wallets.
+
+**Query Parameters:**
+
+- `input`: JSON string containing Solana payment options input
+
+**Input Format:**
+
+```json
+{
+  "0": {
+    "pubKey": "BK1CMQ2kSvxUNa8pZsfvN2UoZDHWVwgYsXKUVZgURAGF",
+    "usdRequired": 5
+  }
+}
+```
+
+**EVM Response Format:**
 
 ```json
 [
@@ -92,6 +111,60 @@ Enhanced endpoint that returns detailed wallet payment options with token balanc
 ]
 ```
 
+**Solana Response Format:**
+
+```json
+[
+  {
+    "result": {
+      "data": [
+        {
+          "required": {
+            "token": {
+              "chainId": 501,
+              "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              "symbol": "USDC",
+              "usd": 1,
+              "priceFromUsd": 1,
+              "decimals": 6,
+              "displayDecimals": 2,
+              "logoSourceURI": "https://pay.daimo.com/coin-logos/usdc.png",
+              "logoURI": "https://pay.daimo.com/coin-logos/usdc.png",
+              "maxAcceptUsd": 100000,
+              "maxSendUsd": 0
+            },
+            "amount": "5000000",
+            "usd": 5
+          },
+          "balance": {
+            "token": {
+              /* same token object */
+            },
+            "amount": "2500000",
+            "usd": 2.5
+          },
+          "minimumRequired": {
+            "token": {
+              /* same token object */
+            },
+            "amount": "100000",
+            "usd": 0.1
+          },
+          "fees": {
+            "token": {
+              /* same token object */
+            },
+            "amount": "0",
+            "usd": 0
+          },
+          "disabledReason": "Balance too low: $2.50"
+        }
+      ]
+    }
+  }
+]
+```
+
 ### Mock Endpoints
 
 - `GET /previewOrder` - Returns mock order preview data
@@ -99,6 +172,7 @@ Enhanced endpoint that returns detailed wallet payment options with token balanc
 - `GET /untronHasAvailableReceivers` - Mock Tron receivers check
 - `POST /nav,nav` - Mock multiple navigation actions
 - `GET /getExternalPaymentOptions,getDepositAddressOptions` - Mock external payment and deposit options
+- `GET /getSolanaPaymentOptions` - Enhanced Solana USDC balance and payment options
 
 ## Configuration
 
@@ -181,6 +255,28 @@ export type Token = {
 - `knownTokens` - All supported tokens across chains
 - `knownAlchemyTokens` - Tokens with Alchemy network mappings
 - `knownTokensByAlchemyNetwork` - Tokens grouped by Alchemy network
+
+### `evm.ts`
+
+Handles EVM chain wallet payment options and token balance retrieval.
+
+**Key Functions:**
+
+- `getTokensBalance()` - Fetches and processes token balances for EVM wallets
+- Supports multiple EVM chains (Base, Polygon, Arbitrum)
+- Integrates with Alchemy Portfolio API for real-time balance data
+- Calculates payment requirements, fees, and balance sufficiency
+
+### `solana.ts`
+
+Handles Solana wallet payment options and USDC balance retrieval.
+
+**Key Functions:**
+
+- `getSolanaPaymentOptions()` - Fetches USDC balance for Solana wallets
+- Uses Associated Token Account (ATA) derivation for USDC balances
+- Integrates with Alchemy Solana RPC for balance queries
+- Provides structured payment option data similar to EVM chains
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@solana/spl-token": "^0.4.14",
+        "@solana/web3.js": "^1.98.4",
         "alchemy-sdk": "^3.6.3",
         "axios": "^1.6.0",
         "cors": "^2.8.5",
@@ -847,6 +849,37 @@
         "node": ">=5.10"
       }
     },
+    "node_modules/@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
     "node_modules/@solana/codecs-core": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
@@ -860,6 +893,70 @@
       },
       "peerDependencies": {
         "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@solana/codecs-numbers": {
@@ -876,6 +973,121 @@
       },
       "peerDependencies": {
         "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@solana/errors": {
@@ -895,6 +1107,121 @@
       },
       "peerDependencies": {
         "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-token": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
+      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
       }
     },
     "node_modules/@solana/web3.js": {
@@ -1317,6 +1644,28 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
       "license": "MIT"
     },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1328,6 +1677,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bn.js": {
@@ -1970,6 +2328,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
     "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@solana/spl-token": "^0.4.14",
+    "@solana/web3.js": "^1.98.4",
     "alchemy-sdk": "^3.6.3",
     "axios": "^1.6.0",
     "cors": "^2.8.5",

--- a/src/lib/evm.ts
+++ b/src/lib/evm.ts
@@ -25,7 +25,7 @@ interface TokenBalance {
 
 export interface GetWalletPaymentOptionsInput {
   payerAddress: string;
-  usdRequired: number;
+  usdRequired?: number;
   destChainId: number;
 }
 
@@ -34,6 +34,8 @@ export async function getEvmTokensBalance({
   usdRequired,
   destChainId,
 }: GetWalletPaymentOptionsInput) {
+  // Handle empty or undefined usdRequired
+  const normalizedUsdRequired = usdRequired || 0;
   const tokenMap = new Map(knownTokens.map((token) => [token.token, token]));
   const response = await alchemy.portfolio.getTokensByWallet([
     {
@@ -63,7 +65,7 @@ export async function getEvmTokensBalance({
 
       return createEvmPaymentOption(
         balanceValue,
-        usdRequired,
+        normalizedUsdRequired,
         knownToken,
         decimals
       );

--- a/src/lib/evm.ts
+++ b/src/lib/evm.ts
@@ -1,0 +1,151 @@
+import {
+  Network,
+  TokenMetadataResponse,
+  TokenPriceByAddressResult,
+} from "alchemy-sdk";
+import { formatUnits, getAddress, hexToBigInt } from "viem";
+import { alchemy } from "../server";
+import { knownAlchemyTokens, knownTokens, Token } from "./token";
+
+interface TokenBalance {
+  id: string;
+  network: Network;
+  address: string;
+  tokenBalance: string;
+  tokenMetadata?: TokenMetadataResponse;
+  tokenPrices?: TokenPriceByAddressResult;
+  tokenAddress?: string;
+  symbol?: string;
+  name: string;
+  chainId: number;
+  balance: number;
+  decimals?: number;
+  logoURI?: string;
+}
+
+export interface GetWalletPaymentOptionsInput {
+  payerAddress: string;
+  usdRequired: number;
+  destChainId: number;
+}
+
+export async function getEvmTokensBalance({
+  payerAddress,
+  usdRequired,
+  destChainId,
+}: GetWalletPaymentOptionsInput) {
+  const tokenMap = new Map(knownTokens.map((token) => [token.token, token]));
+  const response = await alchemy.portfolio.getTokensByWallet([
+    {
+      address: payerAddress,
+      networks: knownAlchemyTokens.map((token) => token.alchemyNetwork),
+    },
+  ]);
+
+  const processedTokens = (response.data.tokens as TokenBalance[])
+    .map((item) => {
+      if (!item.tokenAddress) return null;
+
+      const tokenAddress = getAddress(item.tokenAddress);
+      const knownToken = tokenMap.get(tokenAddress);
+
+      if (!knownToken) return null;
+
+      const balanceBigInt = hexToBigInt(item.tokenBalance as `0x${string}`);
+      const decimals =
+        item.tokenMetadata?.decimals ?? knownToken.decimals ?? 18;
+      const formattedBalance = formatUnits(balanceBigInt, decimals);
+      const balanceValue = Number.parseFloat(
+        Number.parseFloat(formattedBalance).toFixed(
+          knownToken.decimals === 18 ? 5 : 2
+        )
+      );
+
+      return createEvmPaymentOption(
+        balanceValue,
+        usdRequired,
+        knownToken,
+        decimals
+      );
+    })
+    .filter(Boolean)
+    .sort((a, b) => {
+      const balanceA = a?.balance?.usd || 0;
+      const balanceB = b?.balance?.usd || 0;
+      return balanceB - balanceA;
+    });
+
+  return processedTokens;
+}
+
+function createEvmPaymentOption(
+  balanceValue: number,
+  usdRequired: number,
+  knownToken: Token,
+  decimals: number
+) {
+  // Assume 1 USD = 1 token for stablecoins (USDC), adjust as needed for other tokens
+  const usdPrice = knownToken.fiatISO === "USD" ? 1 : 1; // This should be dynamic based on actual price feeds
+  const balanceUsd = balanceValue * usdPrice;
+
+  // Calculate required amount in token units
+  const requiredTokenAmount = Math.ceil(
+    (usdRequired / usdPrice) * Math.pow(10, decimals)
+  );
+  const requiredUsd = usdRequired;
+
+  // Calculate minimum required (assume 10 cents minimum)
+  const minimumUsd = 0.1;
+  const minimumTokenAmount = Math.ceil(
+    (minimumUsd / usdPrice) * Math.pow(10, decimals)
+  );
+
+  // Calculate fees (assume no fees for now)
+  const feesUsd = 0;
+  const feesTokenAmount = "0";
+
+  // Check if balance is sufficient
+  const isBalanceSufficient = balanceUsd >= requiredUsd;
+  const disabledReason = isBalanceSufficient
+    ? undefined
+    : `Balance too low: $${balanceUsd.toFixed(2)}`;
+
+  // Create the token metadata object
+  const tokenMetadata = {
+    chainId: knownToken.chainId,
+    token: knownToken.token,
+    symbol: knownToken.symbol,
+    usd: usdPrice,
+    priceFromUsd: usdPrice,
+    decimals: knownToken.decimals,
+    displayDecimals: knownToken.decimals === 18 ? 5 : 2,
+    logoSourceURI: knownToken.logoSourceURI,
+    logoURI: knownToken.logoURI,
+    maxAcceptUsd: isBalanceSufficient ? 100000 : 30000, // Different limits based on balance
+    maxSendUsd: 0,
+  };
+
+  return {
+    required: {
+      token: tokenMetadata,
+      amount: requiredTokenAmount.toString(),
+      usd: requiredUsd,
+    },
+    balance: {
+      token: tokenMetadata,
+      amount: Math.floor(balanceValue * Math.pow(10, decimals)).toString(),
+      usd: balanceUsd,
+    },
+    minimumRequired: {
+      token: tokenMetadata,
+      amount: minimumTokenAmount.toString(),
+      usd: minimumUsd,
+    },
+    fees: {
+      token: tokenMetadata,
+      amount: feesTokenAmount,
+      usd: feesUsd,
+    },
+    ...(disabledReason && { disabledReason }),
+  };
+}

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -1,0 +1,130 @@
+import { getAssociatedTokenAddress } from "@solana/spl-token";
+import { PublicKey } from "@solana/web3.js";
+import { solanaUSDC } from "./token";
+
+const USDC_MINT = new PublicKey(solanaUSDC.token);
+
+export interface GetSolanaPaymentOptionsInput {
+  pubKey: string;
+  usdRequired: number;
+}
+
+export async function getSolanaPaymentOptions({
+  pubKey,
+  usdRequired,
+}: GetSolanaPaymentOptionsInput) {
+  try {
+    // Derive ATA
+    const ata = await getAssociatedTokenAddress(
+      USDC_MINT,
+      new PublicKey(pubKey)
+    );
+
+    const response = await fetch(
+      `https://solana-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "getTokenAccountBalance",
+          params: [
+            ata.toString(),
+            {
+              commitment: "confirmed",
+            },
+          ],
+          id: 1,
+        }),
+      }
+    );
+
+    const body = (await response.json()) as any;
+
+    // Handle RPC errors
+    if (body.error) {
+      console.log("RPC Error:", body.error);
+      // If account doesn't exist, balance is 0
+      if (
+        body.error.code === -32602 ||
+        body.error.message?.includes("could not find account")
+      ) {
+        return createPaymentOption(0, usdRequired);
+      }
+      throw new Error(`RPC Error: ${body.error.message}`);
+    }
+
+    const balanceData = body.result?.value;
+    if (!balanceData) {
+      return createPaymentOption(0, usdRequired);
+    }
+
+    // Convert balance from token units to decimal
+    const balanceValue =
+      Number.parseFloat(balanceData.amount) /
+      Math.pow(10, balanceData.decimals);
+
+    return createPaymentOption(balanceValue, usdRequired);
+  } catch (error) {
+    console.error("Error fetching Solana payment options:", error);
+    return createPaymentOption(0, usdRequired);
+  }
+}
+
+function createPaymentOption(balanceValue: number, usdRequired: number) {
+  const decimals = solanaUSDC.decimals;
+  const usdPrice = 1; // 1 USD = 1 USDC
+  const balanceUsd = balanceValue * usdPrice;
+
+  // Calculate amounts in token units
+  const requiredTokenAmount = Math.ceil(usdRequired * Math.pow(10, decimals));
+  const minimumTokenAmount = Math.ceil(0.1 * Math.pow(10, decimals)); // 10 cents minimum
+
+  // Check if balance is sufficient
+  const isBalanceSufficient = balanceUsd >= usdRequired;
+  const disabledReason = isBalanceSufficient
+    ? undefined
+    : `Balance too low: $${balanceUsd.toFixed(2)}`;
+
+  const tokenMetadata = {
+    chainId: solanaUSDC.chainId,
+    token: solanaUSDC.token,
+    symbol: solanaUSDC.symbol,
+    usd: usdPrice,
+    priceFromUsd: usdPrice,
+    decimals: solanaUSDC.decimals,
+    displayDecimals: 2,
+    logoSourceURI: solanaUSDC.logoSourceURI,
+    logoURI: solanaUSDC.logoURI,
+    maxAcceptUsd: isBalanceSufficient ? 100000 : 30000,
+    maxSendUsd: 0,
+  };
+
+  return [
+    {
+      required: {
+        token: tokenMetadata,
+        amount: requiredTokenAmount.toString(),
+        usd: usdRequired,
+      },
+      balance: {
+        token: tokenMetadata,
+        amount: Math.floor(balanceValue * Math.pow(10, decimals)).toString(),
+        usd: Number(balanceUsd.toFixed(2)),
+      },
+      minimumRequired: {
+        token: tokenMetadata,
+        amount: minimumTokenAmount.toString(),
+        usd: 0.1,
+      },
+      fees: {
+        token: tokenMetadata,
+        amount: "0",
+        usd: 0,
+      },
+      ...(disabledReason && { disabledReason }),
+    },
+  ];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,8 @@ import {
 } from "alchemy-sdk";
 import { formatUnits, getAddress, hexToBigInt } from "viem";
 import { knownAlchemyTokens, knownTokens } from "./lib/token";
+import { getEvmTokensBalance } from './lib/evm';
+import { getSolanaPaymentOptions } from './lib/solana';
 
 // Load environment variables - check for env.dev first if in development
 if (process.env.NODE_ENV === 'development') {
@@ -253,7 +255,6 @@ app.get('/getExternalPaymentOptions,getDepositAddressOptions', (req: Request, re
 app.get(
   "/getWalletPaymentOptions",
   async (req: Request, res: Response): Promise<void> => {
-    const tokenMap = new Map(knownTokens.map((token) => [token.token, token]));
     const input = req.query.input;
 
     const inputData =
@@ -261,112 +262,29 @@ app.get(
         ? Object.values(JSON.parse(input))
         : Object.values(input || {});
 
-    const data = inputData[0] as GetWalletPaymentOptionsInput;
+    const data = inputData[0];
 
-    if (!data) {
-      res.status(400).json({ error: "Invalid input" });
+    if (
+      !data ||
+      typeof data !== "object" ||
+      !("payerAddress" in data) ||
+      !("usdRequired" in data) ||
+      !("destChainId" in data)
+    ) {
+      res.status(400).json({
+        error: "Invalid input",
+        message:
+          "Expected object with payerAddress, usdRequired, and destChainId properties",
+        received: data,
+      });
       return;
     }
 
-    const response = await alchemy.portfolio.getTokensByWallet([
-      {
-        address: data.payerAddress,
-        networks: knownAlchemyTokens.map((token) => token.alchemyNetwork),
-      },
-    ]);
+    console.log("data", data);
 
-    const processedTokens = (response.data.tokens as TokenBalance[])
-      .map((item) => {
-        if (!item.tokenAddress) return null;
-
-        const tokenAddress = getAddress(item.tokenAddress);
-        const knownToken = tokenMap.get(tokenAddress);
-
-        if (!knownToken) return null;
-
-        const balanceBigInt = hexToBigInt(item.tokenBalance as `0x${string}`);
-        const decimals =
-          item.tokenMetadata?.decimals ?? knownToken.decimals ?? 18;
-        const formattedBalance = formatUnits(balanceBigInt, decimals);
-        const balanceValue = Number.parseFloat(
-          Number.parseFloat(formattedBalance).toFixed(
-            knownToken.decimals === 18 ? 5 : 2
-          )
-        );
-
-        // Assume 1 USD = 1 token for stablecoins (USDC), adjust as needed for other tokens
-        const usdPrice = knownToken.fiatISO === "USD" ? 1 : 1; // This should be dynamic based on actual price feeds
-        const balanceUsd = balanceValue * usdPrice;
-
-        // Calculate required amount in token units
-        const requiredTokenAmount = Math.ceil(
-          (data.usdRequired / usdPrice) * Math.pow(10, decimals)
-        );
-        const requiredUsd = data.usdRequired;
-
-        // Calculate minimum required (assume 10 cents minimum)
-        const minimumUsd = 0.1;
-        const minimumTokenAmount = Math.ceil(
-          (minimumUsd / usdPrice) * Math.pow(10, decimals)
-        );
-
-        // Calculate fees (assume no fees for now)
-        const feesUsd = 0;
-        const feesTokenAmount = "0";
-
-        // Check if balance is sufficient
-        const isBalanceSufficient = balanceUsd >= requiredUsd;
-        const disabledReason = isBalanceSufficient
-          ? undefined
-          : `Balance too low: $${balanceUsd.toFixed(2)}`;
-
-        // Create the token metadata object
-        const tokenMetadata = {
-          chainId: knownToken.chainId,
-          token: knownToken.token,
-          symbol: knownToken.symbol,
-          usd: usdPrice,
-          priceFromUsd: usdPrice,
-          decimals: knownToken.decimals,
-          displayDecimals: knownToken.decimals === 18 ? 5 : 2,
-          logoSourceURI: knownToken.logoSourceURI,
-          logoURI: knownToken.logoURI,
-          maxAcceptUsd: isBalanceSufficient ? 100000 : 30000, // Different limits based on balance
-          maxSendUsd: 0,
-        };
-
-        return {
-          required: {
-            token: tokenMetadata,
-            amount: requiredTokenAmount.toString(),
-            usd: requiredUsd,
-          },
-          balance: {
-            token: tokenMetadata,
-            amount: Math.floor(
-              balanceValue * Math.pow(10, decimals)
-            ).toString(),
-            usd: balanceUsd,
-          },
-          minimumRequired: {
-            token: tokenMetadata,
-            amount: minimumTokenAmount.toString(),
-            usd: minimumUsd,
-          },
-          fees: {
-            token: tokenMetadata,
-            amount: feesTokenAmount,
-            usd: feesUsd,
-          },
-          ...(disabledReason && { disabledReason }),
-        };
-      })
-      .filter(Boolean)
-      .sort((a, b) => {
-        const balanceA = a?.balance?.usd || 0;
-        const balanceB = b?.balance?.usd || 0;
-        return balanceB - balanceA;
-      });
+    const processedTokens = await getEvmTokensBalance(
+      data as GetWalletPaymentOptionsInput
+    );
 
     res.json([
       {
@@ -375,6 +293,50 @@ app.get(
         },
       },
     ]);
+  }
+);
+
+/**
+ * Enhanced getSolanaPaymentOptions endpoint
+ *
+ * @example
+ * getSolanaPaymentOptions?input={"0":{"pubKey":"BK1CMQ2kSvxUNa8pZsfvN2UoZDHWVwgYsXKUVZgURAGF","usdRequired":5}}
+ */
+app.get(
+  "/getSolanaPaymentOptions",
+  async (req: Request, res: Response): Promise<void> => {
+    const input = req.query.input;
+    const inputData =
+      typeof input === "string"
+        ? Object.values(JSON.parse(input))
+        : Object.values(input || {});
+    const data = inputData[0] as any;
+
+    console.log("getSolanaPaymentOptions input:", data);
+
+    if (!data?.pubKey) {
+      res.status(400).json({ error: "pubKey is required" });
+      return;
+    }
+
+    if (!data?.usdRequired || typeof data.usdRequired !== "number") {
+      res.status(400).json({ error: "usdRequired must be a number" });
+      return;
+    }
+
+    try {
+      const processedTokens = await getSolanaPaymentOptions({
+        pubKey: data.pubKey,
+        usdRequired: data.usdRequired,
+      });
+
+      console.log("getSolanaPaymentOptions result:", processedTokens);
+
+      res.json([{ result: { data: processedTokens } }]);
+    } catch (error) {
+      console.error("Error in getSolanaPaymentOptions:", error);
+      res.status(500).json({ error: "Internal server error" });
+    }
   }
 );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -268,13 +268,25 @@ app.get(
       !data ||
       typeof data !== "object" ||
       !("payerAddress" in data) ||
-      !("usdRequired" in data) ||
       !("destChainId" in data)
     ) {
       res.status(400).json({
         error: "Invalid input",
-        message:
-          "Expected object with payerAddress, usdRequired, and destChainId properties",
+        message: "Expected object with payerAddress and destChainId properties",
+        received: data,
+      });
+      return;
+    }
+
+    // Validate usdRequired if provided
+    if (
+      "usdRequired" in data &&
+      data.usdRequired !== undefined &&
+      typeof data.usdRequired !== "number"
+    ) {
+      res.status(400).json({
+        error: "Invalid input",
+        message: "usdRequired must be a number if provided",
         received: data,
       });
       return;
@@ -319,8 +331,17 @@ app.get(
       return;
     }
 
-    if (!data?.usdRequired || typeof data.usdRequired !== "number") {
-      res.status(400).json({ error: "usdRequired must be a number" });
+    // Validate usdRequired if provided
+    if (
+      "usdRequired" in data &&
+      data.usdRequired !== undefined &&
+      typeof data.usdRequired !== "number"
+    ) {
+      res.status(400).json({
+        error: "Invalid input",
+        message: "usdRequired must be a number if provided",
+        received: data,
+      });
       return;
     }
 


### PR DESCRIPTION
Introduces a new /getSolanaPaymentOptions endpoint to fetch USDC balances and payment options for Solana wallets, using Alchemy Solana RPC and ATA derivation. Refactors EVM payment option logic into src/lib/evm.ts for modularity and updates /getWalletPaymentOptions to use the new helper. Updates documentation and adds Solana dependencies.